### PR TITLE
unique path 풀이

### DIFF
--- a/leetcode/uniquePath.js
+++ b/leetcode/uniquePath.js
@@ -1,0 +1,12 @@
+var uniquePaths = function (m, n) {
+  const arr = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
+
+  arr[1][0] = 1;
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      arr[i][j] = arr[i - 1][j] + arr[i][j - 1];
+    }
+  }
+
+  return arr[m][n];
+};


### PR DESCRIPTION
down, right 방향으로만 움직일 수 있기 때문에 `arr[i][j]`칸에 도달할 수 있는 경우의 수는 
`down 방향으로 올 수 있는 경우의 수`와 `right 방향으로 올 수 있는 경우의 수`의 합이다.

따라서 [m+1][n+1] 크기의 이중배열을 만들고 시작지점 arr[1][0]의 값을 1로 지정해둔다.